### PR TITLE
Update __init__.py

### DIFF
--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -117,3 +117,7 @@ def get_tokens(url, user_agent=None):
 def get_cookie_string(url, user_agent=None):
     tokens, user_agent = get_tokens(url, user_agent=user_agent)
     return "; ".join("=".join(pair) for pair in tokens.items()), user_agent
+
+def disable_ssl(session):
+    sesssion.verify=False
+    


### PR DESCRIPTION
I was having issues getting SSL to verify on a certain domain on Ubuntu 14.04.2 LTS, this adds a method to disable SSL verification across the session.

Example of new method:

scraper = cfscrape.create_scraper()
cfscrape.disable_ssl(scraper)

Error message I was getting:

Traceback (most recent call last):
  File "cfscape.py", line 7, in <module>
    print scraper.get(sys.argv[1]).content
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 467, in get
    return self.request('GET', url, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 455, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 558, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/cfscrape/__init__.py", line 22, in send
    resp = super(CloudflareAdapter, self).send(request, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/adapters.py", line 385, in send
    raise SSLError(e)
requests.exceptions.SSLError: [Errno 1] _ssl.c:510: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed