### PR TITLE
Make JS engine selection deterministic, repeatable

### DIFF
--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -12,9 +12,12 @@ except ImportError:
 DEFAULT_USER_AGENT = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:39.0) Gecko/20100101 Firefox/39.0"
 
 class JSEngineNames(object):
+    nashorn = 'Nashorn'
     node = 'Node'
-    v8 = 'V8'
+    phantomjs = 'PhantomJS'
     pyv8 = 'PyV8'
+    slimerjs = 'SlimerJS'
+    v8 = 'V8'
 
 class CloudflareAdapter(HTTPAdapter):
     _supported_js_engine_names = [


### PR DESCRIPTION
This is a re-opened version of #41 , which was closed because I'm bad at github. 

- set a more obvious preferred-order of supported js engines, rather than rely on dict-key-sort-order from execjs
- bind a js_engine inside CloudflareAdapter
- test for supported js engine at runtime, not import-time. This makes testing easier, and allows for changes in environment between import-time and request-time
- create JSEngineNames for symbolic lookup of of magic strings
- change the string representing Node.js to "Node" to match execjs
- make this file pass pyflakes, strip whitespace