### PR TITLE
create_scraper expect keyword `sess` instead of `session`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ scraper = cfscrape.create_scraper(js_engine="Node")
 If you already have an existing requests session, you can pass it to `create_scraper()` to continue using that session.
 
 ```python
-sess = requests.session()
-sess.headers = ...
-scraper = cfscrape.create_scraper(session=sess)
+session = requests.session()
+session.headers = ...
+scraper = cfscrape.create_scraper(sess=session)
 ```
 
 Unfortunately, not all of requests' session attributes are easily transferable, so if you run into problems with this, you should replace your initial `sess = requests.session()` call with `sess = cfscrape.create_scraper()`.


### PR DESCRIPTION
https://github.com/Anorov/cloudflare-scrape/blob/948470e2d97c10295cf8801e569aeaf78db09ea0/cfscrape/__init__.py#L97