### PR TITLE
Fix performing requests other than GET initially.

### DIFF
--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -5,6 +5,7 @@ import re
 import os
 from requests.sessions import Session
 import js2py
+from copy import deepcopy
 
 try:
     from urlparse import urlparse
@@ -40,7 +41,7 @@ class CloudflareScraper(Session):
         # Otherwise, no Cloudflare anti-bot detected
         return resp
 
-    def solve_cf_challenge(self, resp, **kwargs):
+    def solve_cf_challenge(self, resp, **original_kwargs):
         sleep(5)  # Cloudflare requires a delay before solving the challenge
 
         body = resp.text
@@ -48,8 +49,9 @@ class CloudflareScraper(Session):
         domain = urlparse(resp.url).netloc
         submit_url = "%s://%s/cdn-cgi/l/chk_jschl" % (parsed_url.scheme, domain)
 
-        params = kwargs.setdefault("params", {})
-        headers = kwargs.setdefault("headers", {})
+        cloudflare_kwargs = deepcopy(original_kwargs)
+        params = cloudflare_kwargs.setdefault("params", {})
+        headers = cloudflare_kwargs.setdefault("headers", {})
         headers["Referer"] = resp.url
 
         try:
@@ -75,7 +77,13 @@ class CloudflareScraper(Session):
         js = js.replace('return', '')
         params["jschl_answer"] = str(int(js2py.eval_js(js)) + len(domain))
 
-        return self.get(submit_url, **kwargs)
+        # Requests transforms any request into a GET after a redirect,
+        # so the redirect has to be handled manually here to allow for
+        # performing other types of requests even as the first request.
+        method = resp.request.method
+        cloudflare_kwargs['allow_redirects'] = False
+        redirect = self.request(method, submit_url, **cloudflare_kwargs)
+        return self.request(method, redirect.headers['Location'], **original_kwargs)
 
     def extract_js(self, body):
         js = re.search(r"setTimeout\(function\(\){\s+(var "


### PR DESCRIPTION
As mentioned in #39, trying to perform any request other than a GET as the first request of a scraper fails. After some research, it turns out this is due to a standard bug in how redirects are handled. According to the RFC in place, the performer of the request should retry the request with the original method at the new location. However, in practice browsers started unconditionally performing a GET when redirected, and... `requests` followed suit to match the "expected behavior". [See here for more info](http://stackoverflow.com/a/19422232/2280091).

So with this pull request, the redirect CloudFlare gives is handled manually and thus allows the user to perform, for example, a POST request initially and have it be handled correctly. This is very important, as `cfscrape` can't otherwise be reliably used for requests other than GET.

The pull request also fixes a minor bug where you couldn't specify `allow_redirects` without getting the wrong response - necessary for the fix.