### PR TITLE
Fix the 'requests.exceptions.MissingSchema: Invalid URL '/': No schem…

### DIFF
--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -82,6 +82,8 @@ class CloudflareScraper(Session):
         method = resp.request.method
         cloudflare_kwargs["allow_redirects"] = False
         redirect = self.request(method, submit_url, **cloudflare_kwargs)
+        if redirect.headers["Location"] == '/':
+            return redirect
         return self.request(method, redirect.headers["Location"], **original_kwargs)
 
     def solve_challenge(self, body):


### PR DESCRIPTION
When redirect.headers["Location"] == '/' the requests library throws requests.exceptions.MissingSchema: Invalid URL '/': No schema supplied. Perhaps you meant http:///