### PR TITLE
Optimized code

### DIFF
--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -2,8 +2,8 @@ import logging
 import random
 import re
 import subprocess
-from copy import deepcopy
-from time import sleep
+import copy
+import time
 
 from requests.sessions import Session
 
@@ -70,14 +70,14 @@ class CloudflareScraper(Session):
         return resp
 
     def solve_cf_challenge(self, resp, **original_kwargs):
-        sleep(self.delay)  # Cloudflare requires a delay before solving the challenge
+        start_time = time.time()
 
         body = resp.text
         parsed_url = urlparse(resp.url)
         domain = parsed_url.netloc
         submit_url = "%s://%s/cdn-cgi/l/chk_jschl" % (parsed_url.scheme, domain)
 
-        cloudflare_kwargs = deepcopy(original_kwargs)
+        cloudflare_kwargs = copy.deepcopy(original_kwargs)
         params = cloudflare_kwargs.setdefault("params", {})
         headers = cloudflare_kwargs.setdefault("headers", {})
         headers["Referer"] = resp.url
@@ -85,7 +85,6 @@ class CloudflareScraper(Session):
         try:
             params["jschl_vc"] = re.search(r'name="jschl_vc" value="(\w+)"', body).group(1)
             params["pass"] = re.search(r'name="pass" value="(.+?)"', body).group(1)
-
         except Exception as e:
             # Something is wrong with the page.
             # This may indicate Cloudflare has changed their anti-bot
@@ -101,6 +100,10 @@ class CloudflareScraper(Session):
         # performing other types of requests even as the first request.
         method = resp.request.method
         cloudflare_kwargs["allow_redirects"] = False
+
+        end_time = time.time()
+        time.sleep(self.delay - (end_time - start_time)) # Cloudflare requires a delay before solving the challenge
+
         redirect = self.request(method, submit_url, **cloudflare_kwargs)
 
         redirect_location = urlparse(redirect.headers["Location"])


### PR DESCRIPTION
In the current implementation, the script waits 8 seconds no matter how much time node took to parse javascript. In this PR, I changed it to count how many seconds it took to parse and evaluate the javascript, then it calculates how much time it still needs to wait. This reduces the time the library needs.
(This PR also removes some `from` imports)