### PR TITLE
Avoid captcha challenges

### DIFF
--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -95,6 +95,9 @@ class CloudflareScraper(Session):
         # Define headers to force using an OrderedDict and preserve header order
         self.headers = headers
 
+        # AES128-SHA ciphers seem to provoke a cloudflare challenge captcha.
+        self.captcha_adapter = CaptchaProvokingCiphersRemover()
+
     @staticmethod
     def is_cloudflare_iuam_challenge(resp):
         return (
@@ -318,7 +321,7 @@ class CloudflareScraper(Session):
         adapter = self.get_adapter(CaptchaProvokingCiphersRemover.url)
 
         if not isinstance(adapter, CaptchaProvokingCiphersRemover):
-            self.mount(CaptchaProvokingCiphersRemover.url, CloudflareScraper.captcha_adapter)
+            self.mount(CaptchaProvokingCiphersRemover.url, self.captcha_adapter)
 
     def unmount_adapter(self):
         adapter = self.get_adapter(CaptchaProvokingCiphersRemover.url)

--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -71,7 +71,7 @@ class ExcludeCaptchaProvokingCiphersAdapter(HTTPAdapter):
         conn = super(ExcludeCaptchaProvokingCiphersAdapter, self).get_connection(url, proxies)
         # Only if enable() has been explicitly invoked, the ciphers are updated.
         if getattr(self, "is_enabled", False):
-            conn.conn_kw['ssl_context'] = create_urllib3_context(ciphers=DEFAULT_CIPHERS + ":!ECDHE+SHA")
+            conn.conn_kw['ssl_context'] = create_urllib3_context(ciphers=DEFAULT_CIPHERS + ":!ECDHE+SHA:!AES128-SHA")
 
         return conn
 

--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -15,7 +15,7 @@ from requests.adapters import HTTPAdapter
 from requests.compat import urlparse, urlunparse
 from requests.exceptions import RequestException
 
-from requests.urllib3.util.ssl_ import create_urllib3_context
+from urllib3.util.ssl_ import create_urllib3_context
 
 __version__ = "2.0.3"
 

--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -136,10 +136,10 @@ class CloudflareScraper(Session):
         return resp
 
     def cloudflare_is_bypassed(self, url, resp=None):
-        domain = urlparse(url).netloc
+        cookie_domain = ".{}".format(urlparse(url).netloc)
         return (
-            self.cookies.get("cf_clearance", None, domain=domain) or
-                (resp and resp.cookies.get("cf_clearance", None, domain=domain))
+            self.cookies.get("cf_clearance", None, domain=cookie_domain) or
+                (resp and resp.cookies.get("cf_clearance", None, domain=cookie_domain))
         )
 
     def handle_captcha_challenge(self, resp, url):

--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -79,9 +79,6 @@ class CloudflareCaptchaError(CloudflareError):
 
 
 class CloudflareScraper(Session):
-    # AES128-SHA ciphers seem to provoke a cloudflare challenge captcha.
-    captcha_adapter = CaptchaProvokingCiphersRemover()
-
     def __init__(self, *args, **kwargs):
         self.delay = kwargs.pop("delay", None)
         # Use headers with a random User-Agent if no custom headers have been set

--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -71,7 +71,7 @@ class ExcludeCaptchaProvokingCiphersAdapter(HTTPAdapter):
         conn = super(ExcludeCaptchaProvokingCiphersAdapter, self).get_connection(url, proxies)
         # Only if enable() has been explicitly invoked, the ciphers are updated.
         if getattr(self, "is_enabled", False):
-            conn.conn_kw['ssl_context'] = create_urllib3_context(ciphers=DEFAULT_CIPHERS + "!ECDHE+SHA")
+            conn.conn_kw['ssl_context'] = create_urllib3_context(ciphers=DEFAULT_CIPHERS + ":!ECDHE+SHA")
 
         return conn
 

--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -65,7 +65,7 @@ class CaptchaProvokingCiphersRemover(HTTPAdapter):
         context = create_urllib3_context()
         problematic_ciphers = ("AES128-SHA",)
 
-        ciphers = [cipher['name'] for cipher in context.get_ciphers() if cipher['name'] in problematic_ciphers]
+        ciphers = [cipher["name"] for cipher in context.get_ciphers() if cipher["name"] in problematic_ciphers]
         context.set_ciphers(":".join(ciphers))
 
         super(CaptchaProvokingCiphersRemover, self).init_poolmanager(*args, ssl_context=context, **kwargs)


### PR DESCRIPTION
SHA1 ciphers seem to be provoking cloudflare captcha challenges.
By removing cipher AES128-SHA captchas can be avoided.