### PR TITLE
Fixed cf new challenge solution

### DIFF
--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -250,7 +250,7 @@ class CloudflareScraper(Session):
 
             challenge, ms = re.search(
                 r"setTimeout\(function\(\){\s*(var "
-                r"s,t,o,p, b,r,e,a,k,i,n,g,f.+?\r?\n[\s\S]+?a\.value\s*=.+?)\r?\n"
+                r"s,t,o,p, b,r,e,a,k,i,n,g,cpo,f.+?\r?\n[\s\S]+?a\.value\s*=.+?)\r?\n"
                 r"(?:[^{<>]*},\s*(\d{4,}))",
                 javascript, flags=re.S
             ).groups()

--- a/cfscrape/__init__.py
+++ b/cfscrape/__init__.py
@@ -20,7 +20,7 @@ from urllib3.util.ssl_ import create_urllib3_context, DEFAULT_CIPHERS
 
 from .user_agents import USER_AGENTS
 
-__version__ = "2.1.1"
+__version__ = "2.1.1-alpha"
 
 DEFAULT_USER_AGENT = random.choice(USER_AGENTS)
 


### PR DESCRIPTION
There was mainly 3 problems:

1. Value of jschl_vc token was taken from commented input element instead of the actual one
2. The value of the div element with its ID as the variable k is split into multiple divs and numbered at the end of the ID for each div
3. node: setInterval not defined. I removed that part from js code

Tested on:
- https://kissanime.ru
- #371 

**EDIT**
As of yesterday the tested websites are no more working, due to the new cf challenge.
The challenge lies within the script at the path that goes like `example.com/cdn-cgi/challenge-platform/orchestrate/jsch/v1`
Once the script is loaded and executed, the function `_cf_chl_enter()` is called.

I will try and see if I can automate the same process in python
