### PR TITLE
Add urllib3 < 2.0.0 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
     url="https://github.com/Anorov/cloudflare-scrape",
     keywords=["cloudflare", "scraping"],
     include_package_data=True,
-    install_requires=["requests >= 2.23.0"],
+    install_requires=["requests >= 2.23.0", "urllib3 < 2.0.0"],
 )


### PR DESCRIPTION
urllib3 introduced a backwards incompatible change that removed the DEFAULT_CIPHERS field.

Causes the following error:

```
File "C:\Users\...\AppData\Local\pypoetry\Cache\virtualenvs\falr-05-2023-V98AjTAw-py3.10\lib\site-packages\faapi\connection.py", line 12, in <module>
    from cfscrape import CloudflareScraper  # type: ignore
  File "C:\Users\...\AppData\Local\pypoetry\Cache\virtualenvs\falr-05-2023-V98AjTAw-py3.10\lib\site-packages\cfscrape\__init__.py", line 19, in <module>
    from urllib3.util.ssl_ import create_urllib3_context, DEFAULT_CIPHERS
ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' (C:\Users\...\AppData\Local\pypoetry\Cache\virtualenvs\falr-05-2023-V98AjTAw-py3.10\lib\site-packages\urllib3\util\ssl_.py)
```